### PR TITLE
Added support to text changes during an event

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "gif-frames": "^1.0.1"
       },
       "devDependencies": {
-        "@types/node": "^20.11.4",
+        "@types/node": "^20.14.2",
         "nodemon": "^3.0.2",
         "prettier": "^3.2.4",
         "typescript": "^5.3.3"
@@ -40,9 +40,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.11.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.4.tgz",
-      "integrity": "sha512-6I0fMH8Aoy2lOejL3s4LhyIYX34DPwY8bl5xlNjBvUEk8OHrcuzsFt+Ied4LvJihbtXPM+8zUqdydfIti86v9g==",
+      "version": "20.14.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.2.tgz",
+      "integrity": "sha512-xyu6WAMVwv6AKFLB+e/7ySZVr/0zLCzOa7rSpq6jNwpqOrUbcACDWC+53d4n2QHOnDou0fbIsg8wZu/sxrnI4Q==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "gif-frames": "^1.0.1"
   },
   "devDependencies": {
-    "@types/node": "^20.11.4",
+    "@types/node": "^20.14.2",
     "nodemon": "^3.0.2",
     "prettier": "^3.2.4",
     "typescript": "^5.3.3"

--- a/src/types.ts
+++ b/src/types.ts
@@ -125,6 +125,46 @@ export interface FontOptions {
 }
 
 /**
+ * Options for settings canvas options.
+ */
+export interface CanvasOptions {
+    /**
+     * The X start of the canvas text.
+     */
+    x: number;
+
+    /**
+     * The Y start of the canvas text.
+     */
+    y: number;
+
+    /**
+     * The text alignment on the x-axis on canvas.
+     * @type {AlignmentXOptions}
+     * @default "center"
+     */
+    textAlign: string;
+
+    /**
+     * The text alignment on the y-axis on canvas.
+     * @type {AlignmentYOptions}
+     * @default "bottom"
+     */
+    textBaseline: string;
+}
+
+/**
+ * Represents an text row.
+ */
+export interface Row {
+    /**
+     * The text row's text.
+     * @type {string}
+     */
+    text: string;
+}
+
+/**
  * Represents an extracted frame.
  */
 export interface ExtractedFrame {


### PR DESCRIPTION
1. Changed how the line breaker was functioning. I noticed that in two different projects, the lines weren't being broken correctly. To address this, I rewrote the code to try to prevent issues like text overflowing the canvas boundaries.
* For this purpose, I added a new function called createTextRows, which generates an array with the texts to be written.
* I also needed to add a new type for the rows: Rows.
2. Modified the code to allow changes in the text (color, string, font size, etc.) and positions (x, y) where the text is placed during an event, such as the "frameIndexUpdate". This helps in creating a gif where the text changes during some frame:
```js
      gif.on("frameIndexUpdate", async (frameIndex) => {
        if (frameIndex == 145) {
          gif.canvasOptions.y = 145

          await gif.setText(string, { fontColor: "red" })
        }
      });
```

* To accomplish this, it was necessary to add a new type: CanvasOptions, with more specific options to be changed.

I believe these are all my changes.